### PR TITLE
Fix stale cache after PWA removal

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -47,6 +47,17 @@ library.add(
   faMapMarkerAlt
 )
 
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .getRegistrations()
+    .then(registrations => {
+      registrations.forEach(reg => {
+        reg.unregister().catch(() => {})
+      })
+    })
+    .catch(() => {})
+}
+
 const app = createApp(App)
 
 // 註冊 FontAwesome 組件


### PR DESCRIPTION
## Summary
- unregister any previously registered service workers on startup

## Testing
- `npm run lint:check`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68543878c3d483238c0c92078190734c