### PR TITLE
Fix cache cleanup interval duplication

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { RouterView } from 'vue-router'
 import AppNavbar from '@/components/AppNavbar.vue'
 import AppFooter from '@/components/AppFooter.vue'
@@ -11,7 +11,7 @@ import { useImageCache } from '@/composables/useImageCache'
 const showLoader = ref(true)
 const { handleCursorHover } = useCustomCursor()
 const { handleHoverAnimation } = useHoverAnimation()
-const { startCacheCleanup } = useImageCache()
+const { startCacheCleanup, stopCacheCleanup } = useImageCache()
 
 onMounted(() => {
   // 初始化游標懸停效果
@@ -24,6 +24,10 @@ onMounted(() => {
 
   // 初始化快取清理
   startCacheCleanup()
+})
+
+onUnmounted(() => {
+  stopCacheCleanup()
 })
 </script>
 

--- a/src/composables/useImageCache.js
+++ b/src/composables/useImageCache.js
@@ -241,15 +241,23 @@ export function useImageCache() {
   }
 
   // 定期清理過期快取
+  let cleanupInterval = null
   const startCacheCleanup = () => {
-    // 每天清理一次過期快取
-    setInterval(
+    if (cleanupInterval) return
+    cleanupInterval = setInterval(
       async () => {
         await cleanExpiredCache()
         await cleanOversizedCache()
       },
       24 * 60 * 60 * 1000
     )
+  }
+
+  const stopCacheCleanup = () => {
+    if (cleanupInterval) {
+      clearInterval(cleanupInterval)
+      cleanupInterval = null
+    }
   }
 
   return {
@@ -259,6 +267,7 @@ export function useImageCache() {
     loadImage,
     preloadImages,
     startCacheCleanup,
+    stopCacheCleanup,
     getCacheSize,
   }
 }

--- a/src/views/ArticleView.vue
+++ b/src/views/ArticleView.vue
@@ -128,7 +128,7 @@ import BackToTop from '@/components/BackToTop.vue'
 
 const route = useRoute()
 const router = useRouter()
-const { preloadImages, loadImage, startCacheCleanup } = useImageCache()
+const { preloadImages, loadImage, startCacheCleanup, stopCacheCleanup } = useImageCache()
 
 // 使用 useScroll 來計算閱讀進度
 const { y } = useScroll(window)
@@ -253,6 +253,10 @@ watch(article, async a => {
 onMounted(() => {
   loadArticle()
   startCacheCleanup()
+})
+
+onUnmounted(() => {
+  stopCacheCleanup()
 })
 </script>
 

--- a/src/views/BlogsView.vue
+++ b/src/views/BlogsView.vue
@@ -192,7 +192,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { articles } from '@/data/articleData.js'
 import { useImageFormat } from '@/composables/useImageFormat.js'
 import { useImageCache } from '@/composables/useImageCache'
@@ -201,7 +201,7 @@ import BackToTop from '@/components/BackToTop.vue'
 const searchQuery = ref('')
 const selectedCategory = ref('all')
 const { toWebP } = useImageFormat()
-const { preloadImages, loadImage, startCacheCleanup } = useImageCache()
+const { preloadImages, loadImage, startCacheCleanup, stopCacheCleanup } = useImageCache()
 const cachedImageUrl = ref({})
 
 // 將 articles 轉換為陣列格式
@@ -287,6 +287,10 @@ onMounted(async () => {
   for (const url of imageUrls) {
     await loadCachedImage(url)
   }
+})
+
+onUnmounted(() => {
+  stopCacheCleanup()
 })
 </script>
 

--- a/src/views/PortfolioView.vue
+++ b/src/views/PortfolioView.vue
@@ -36,12 +36,12 @@ import { useRouter } from 'vue-router'
 import PortfolioList from '@/components/PortfolioList.vue'
 import { useImageCache } from '@/composables/useImageCache'
 import { usePortfolio } from '@/composables/usePortfolio.js'
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useScroll, useIntersectionObserver } from '@vueuse/core'
 import ReadingProgress from '@/components/ReadingProgress.vue'
 import BackToTop from '@/components/BackToTop.vue'
 
-const { preloadImages, startCacheCleanup } = useImageCache()
+const { preloadImages, startCacheCleanup, stopCacheCleanup } = useImageCache()
 const { portfolioData } = usePortfolio()
 const router = useRouter()
 
@@ -82,6 +82,10 @@ onMounted(async () => {
   await preloadGalleryImages()
   // 初始化快取清理
   startCacheCleanup()
+})
+
+onUnmounted(() => {
+  stopCacheCleanup()
 })
 </script>
 


### PR DESCRIPTION
## Summary
- avoid creating multiple cleanup intervals in `useImageCache`
- stop cache cleanup when components unmount to prevent leaks

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint:check` *(fails: cannot find module 'globals')*
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_68544574ce608323afae0372041ea75d